### PR TITLE
Clear the goals when not in proof mode

### DIFF
--- a/html_views/src/goals/StateModel.ts
+++ b/html_views/src/goals/StateModel.ts
@@ -198,8 +198,10 @@ class StateModel {
         this.setErrorMessage(state.message);
       else if(state.type === 'not-running') 
         this.setMessage('Not running.');
-      else if(state.type === 'no-proof')
+      else if(state.type === 'no-proof') {
+        $('#states').empty();
         this.setMessage('Not in proof mode.');
+      }
       else if(state.type === 'interrupted')
         this.setMessage("Interrupted.");
       else if(state.type === 'proof-view') { 

--- a/html_views/src/goals/StateModel.ts
+++ b/html_views/src/goals/StateModel.ts
@@ -194,31 +194,27 @@ class StateModel {
       this.clearErrorMessage();
       $('#stdout').text('');
 
-      if(state.type === 'failure')
+      $('#states').empty();
+      if (state.type === 'failure')
         this.setErrorMessage(state.message);
-      else if(state.type === 'not-running') 
+      else if (state.type === 'not-running') 
         this.setMessage('Not running.');
-      else if(state.type === 'no-proof') {
-        $('#states').empty();
+      else if (state.type === 'no-proof')
         this.setMessage('Not in proof mode.');
-      }
-      else if(state.type === 'interrupted')
+      else if (state.type === 'interrupted')
         this.setMessage("Interrupted.");
-      else if(state.type === 'proof-view') { 
+      else if (state.type === 'proof-view') { 
         if (countAllGoals(state) == 0) {
-          $('#states').empty();
           this.setMessage("No more subgoals.");
         } else if (state.goals) {
           if(state.goals.length > 0) {
             this.setMessage("");
             $('#states')
-            .empty()
             .append(
               [ createHypotheses(state.goals[0].hypotheses)
               , createFocusedGoals(state.goals)
             ])
           } else {
-            $('#states').empty();
             this.setMessage("There are unfocused goals.");
           }
         }


### PR DESCRIPTION
It can be counter-intuitive to persist goals that are no longer relevant, when not in proof mode. This clears any current goals when not in proof mode, which fixes #145.

I think this might also fix #150 (although it's hard to be sure without being able to test it).