### PR TITLE
Output spaces instead of non-breaking spaces

### DIFF
--- a/client/src/prettify-symbols-mode.ts
+++ b/client/src/prettify-symbols-mode.ts
@@ -69,7 +69,7 @@ export function prettyTextToString(txt: text.AnnotatedText) : string {
   const str: string = enabled ? text.textToDisplayString(txt) : text.textToString(txt);
   // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace
   // them here with spaces to allow the user to copy any output and use it directly as input.
-  return str.replace(/\u00a0/g, " ");
+  return str.replace(/\u00a0+/g, " ");
 }
 
 export function load() : vscode.Disposable {

--- a/client/src/prettify-symbols-mode.ts
+++ b/client/src/prettify-symbols-mode.ts
@@ -66,10 +66,10 @@ function onPrettifySymbolsModeEnabledChange(isEnabled: boolean) {
 }
 
 export function prettyTextToString(txt: text.AnnotatedText) : string {
-  if(enabled)
-    return text.textToDisplayString(txt);
-  else
-    return text.textToString(txt);
+  const str: string = enabled ? text.textToDisplayString(txt) : text.textToString(txt);
+  // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace
+  // them here with spaces to allow the user to copy any output and use it directly as input.
+  return str.replace(/\u00a0/g, " ");
 }
 
 export function load() : vscode.Disposable {

--- a/client/src/prettify-symbols-mode.ts
+++ b/client/src/prettify-symbols-mode.ts
@@ -67,9 +67,9 @@ function onPrettifySymbolsModeEnabledChange(isEnabled: boolean) {
 
 export function prettyTextToString(txt: text.AnnotatedText) : string {
   const str: string = enabled ? text.textToDisplayString(txt) : text.textToString(txt);
-  // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace
-  // them here with spaces to allow the user to copy any output and use it directly as input.
-  return str.replace(/\u00a0+/g, " ");
+  // `coqtop` loves outputting non-breaking spaces instead of normal whitespace, so we replace them
+  // here with tabs and spaces to allow the user to copy any output and use it directly as input.
+  return str.replace(/\u00a0{4}/, "\t").replace(/\u00a0/g, " ");
 }
 
 export function load() : vscode.Disposable {


### PR DESCRIPTION
`coqtop` uses non-breaking spaces instead of spaces in its output, which is frustrating when the user just wants to copy and paste the output directly into source. Here we replace non-breaking spaces with spaces in output strings to fix this.